### PR TITLE
fix: user_idの型をint64からstringに修正

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -91,8 +91,7 @@ paths:
       - name: "userID"
         in: "path"
         required: true
-        type: "integer"
-        format: "int64"
+        type: "string"
       responses:
         "200":
           description: "successful operation"
@@ -117,8 +116,7 @@ paths:
       - name: "userID"
         in: "path"
         required: true
-        type: "integer"
-        format: "int64"
+        type: "string"
       responses:
         "200":
           description: "successful operation"
@@ -145,8 +143,7 @@ paths:
       - name: "userID"
         in: "path"
         required: true
-        type: "integer"
-        format: "int64"
+        type: "string"
       responses:
         "200":
           description: "successful operation"
@@ -434,8 +431,7 @@ definitions:
     type: "object"
     properties:
       id:
-        type: "integer"
-        format: "int64"
+        type: "string"
       name:
         type: "string"
       twitter_id:
@@ -463,8 +459,7 @@ definitions:
         type: "integer"
         format: "int64"
       user_id:
-        type: "integer"
-        format: "int64"
+        type: "string"
       title:
         type: "string"
       post:
@@ -507,8 +502,7 @@ definitions:
         type: "integer"
         format: "int64"
       user_id:
-        type: "integer"
-        format: "int64"
+        type: "string"
       post_id:
         type: "integer"
         format: "int64"


### PR DESCRIPTION
## このPRの概要
swagger.yaml内のusre_idの型をint64からstringに修正

## なぜこのPRが何故必要なのか
firebaseが発行するuidのtypeがstringなのでそれに合わせる必要があるため
