### PR TITLE
fix: swaggerのRequest, Responseのフィールド名を修正

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -445,10 +445,13 @@ definitions:
         type: "string"
       code:
         type: "string"
+        description: "ソースコード"
       language:
         type: "string"
+        description: "ソースコードの言語"
       content:
         type: "string"
+        description: "説明の内容"
       source:
         type: "string"
         description: "postの引用元(urlなど)"
@@ -464,10 +467,13 @@ definitions:
         type: "string"
       code:
         type: "string"
+        description: "ソースコード"
       language:
         type: "string"
+        description: "ソースコードの言語"
       content:
         type: "string"
+        description: "説明の内容"
       source:
         type: "string"
         description: "postの引用元(urlなど)"


### PR DESCRIPTION
## このPRの概要
- Post,Commentのフィールド```description```を ```content```に変更
- Postのフィールド```post```を```code```に修正
- いくつかのフィールドに対して説明を追加

## なぜこのPRが何故必要なのか
フィールドの内容をよりわかりやすくするため
