### PR TITLE
fix: 環境変数の扱いを変更

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -4,4 +4,4 @@ WORKDIR /go/src/github.com/openhacku-saboten/OmnisCode-backend/
 
 COPY . .
 
-CMD [ "go", "run", "main.go" ]
+CMD [ "make", "run" ]

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -16,15 +16,6 @@ services:
     build:
       context: ../
       dockerfile: docker/Dockerfile.backend
-    environment:
-      - ENV=test
-      - PORT=8080
-      - DB_DATABASE=test
-      - DB_USER=test
-      - DB_PASSWORD=test
-      - DB_HOST=db
-      - DB_PORT=3306
-      - DB_ROOT_PASSWORD=testpass
     ports:
       - 8080:8080
     restart: always


### PR DESCRIPTION
## このPRの概要

.envを用いて環境変数を扱うようにDockerfileを変更した

## なぜこのPRが何故必要なのか

`docker-compose.yml`と`.env`を用いた方法 で環境変数の扱いが分かれていたのを統一するため