### PR TITLE
feat: userResponseにiconのURLを付与するよう変更

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -438,6 +438,8 @@ definitions:
         type: "string"
       profile:
         type: "string"
+      icon_url:
+        type: "string"
   PostRequest:
     type: "object"
     properties:


### PR DESCRIPTION
## このPRの概要
userResponseに `icon_url` を追加

## なぜこのPRが必要なのか
`icon_url` はバックエンド側で問い合わせて, user responseに載せてあげたほうがフロントに優しいため

ref: https://github.com/openhacku-saboten/OmnisCode-backend/pull/23#issuecomment-802641405