### PR TITLE
fix: branchのtypo修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
## このPRの概要
typoの修正

## なぜこのPRが何故必要なのか
mainにpushしたときにCIを動かすため

