### PR TITLE
Authenticateの際にcontextを正しく受け渡せていなかったので修正

### DIFF
--- a/infra/auth.go
+++ b/infra/auth.go
@@ -17,7 +17,7 @@ func NewAuthRepository(firebase *auth.Client) *AuthRepository {
 
 // Authenticate はTokenをfirebaseに照合してuserIDを返す
 func (a *AuthRepository) Authenticate(ctx context.Context, token string) (uid string, err error) {
-	authToken, err := a.firebase.VerifyIDTokenAndCheckRevoked(context.Background(), token)
+	authToken, err := a.firebase.VerifyIDTokenAndCheckRevoked(ctx, token)
 	if err != nil {
 		return "", fmt.Errorf("error verifying ID token: %w", err)
 	}


### PR DESCRIPTION
## このPRの概要
Authenticateの際にcontextを正しく受け渡せていなかったので修正

## なぜこのPRが何故必要なのか
動作にはほぼ問題ないが直したほうが良いため
