### PR TITLE
cover.htmlをcommitしないようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+cover.html
 
 # Dependency directories (remove the comment below to include it)
 # vendor/


### PR DESCRIPTION
## このPRの概要
make test-with-coverageで出力されるcover.htmlをgitignoreに追加

## なぜこのPRが何故必要なのか
cover.htmlはcommitされるべきファイルではないため
