### PR TITLE
chore: Swaggerの定義に作成日時と最終更新日時を追加

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8,12 +8,12 @@ info:
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
 basePath: "/api/v1"
 tags:
+- name: "user"
+  description: "ユーザー"
 - name: "post"
   description: "スレッドのメインとなる投稿"
 - name: "comment"
   description: "スレッドにつくコメント．コードに対するハイライトor変更が含まれる場合がある"
-- name: "user"
-  description: "ユーザー"
 schemes:
 - "https"
 - "http"


### PR DESCRIPTION
## このPRの概要
Swagger.yamlにCommentとPostに作成日時(created_at)と最終更新日時(updated_at)を追加

## なぜこのPRが何故必要なのか
DBの設計修正後、ドキュメントの更新を行っていなかったため

## めも
yamlの定義順と表示順が異なっていたので、ついでに修正しました。関係ないコミットを積んでしまい、申し訳ないです。