### PR TITLE
chore: 欠けていたcommentのresponse bodyを追加

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -340,6 +340,8 @@ paths:
       responses:
         "200":
           description: "successful operation"
+          schema:
+            $ref: "#/definitions/CommentResponse"
         "404":
           description: "Comment not found"
           schema:


### PR DESCRIPTION
## このPRの概要
#41  でswaggerのAPI仕様を眺めていたら、コメントのレスポンスボディが欠けていたので追加しました

## なぜこのPRが何故必要なのか
コメントのレスポンスボディが欠けていたため