### PR TITLE
error.Asのバグを修正

### DIFF
--- a/controller/comment.go
+++ b/controller/comment.go
@@ -30,9 +30,11 @@ func (ctrl *CommentController) GetByPostID(c echo.Context) error {
 	comments, err := ctrl.uc.GetByPostID(postID)
 
 	if err != nil {
-		if errors.As(err, &entity.ErrNotFound{}) {
-			return echo.NewHTTPError(http.StatusNotFound, err.Error())
+		errNF := &entity.ErrNotFound{}
+		if errors.As(err, errNF) {
+			return echo.NewHTTPError(http.StatusNotFound, errNF.Error())
 		}
+
 		logger.Errorf("Unexpected error GET /post/{postID}/comment: %s", err.Error())
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}

--- a/controller/post.go
+++ b/controller/post.go
@@ -39,9 +39,10 @@ func (ctrl *PostController) Get(c echo.Context) error {
 	post, err := ctrl.uc.Get(ctx, postIDInt)
 
 	if err != nil {
-		if errors.As(err, &entity.ErrNotFound{}) {
+		errNF := &entity.ErrNotFound{}
+		if errors.As(err, errNF) {
 			logger.Error(entity.NewErrorNotFound("post").Error())
-			return echo.NewHTTPError(http.StatusNotFound, err.Error())
+			return echo.NewHTTPError(http.StatusNotFound, errNF.Error())
 		}
 
 		logger.Errorf("unexpected error GET /post/{postID}: %s", err.Error())

--- a/controller/user.go
+++ b/controller/user.go
@@ -94,11 +94,13 @@ func (ctrl *UserController) Update(c echo.Context) error {
 		if errors.Is(err, entity.ErrEmptyUserName) {
 			return echo.NewHTTPError(http.StatusBadRequest, entity.ErrEmptyUserName.Error())
 		}
-		if errors.As(err, &entity.ErrDuplicated{}) {
-			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		errDup := &entity.ErrDuplicated{}
+		if errors.As(err, errDup) {
+			return echo.NewHTTPError(http.StatusBadRequest, errDup.Error())
 		}
-		if errors.As(err, &entity.ErrTooLong{}) {
-			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		errTL := &entity.ErrTooLong{}
+		if errors.As(err, errTL) {
+			return echo.NewHTTPError(http.StatusBadRequest, errTL.Error())
 		}
 		logger.Errorf("Unexpected error PUT/user: %s", err.Error())
 		return echo.NewHTTPError(http.StatusInternalServerError)


### PR DESCRIPTION
## このPRの概要
error.Asで型キャストした値を使うには，第２引数に入れた空の構造体を使う必要があるので修正しました．
mainに存在する分は修正しましたが，別のブランチにある部分は修正しといてもらえるとありがたいです．

## なぜこのPRが必要なのか
レスポンスとして表示するエラーメッセージは```err.Error()```で取得していたが，こうすると例として以下のメッセージが返ってしまう  
```failed to Update User into DB: user TwitterID is duplicated```  
内部の情報を見せるのは良くないので，この修正によって  
```user TwitterID is duplicated```  
のように戻します．

