### PR TITLE
fix: prodに足りないものを追加

### DIFF
--- a/docker/Dockerfile.prod.backend
+++ b/docker/Dockerfile.prod.backend
@@ -5,6 +5,8 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /omniscode-backend
 
 FROM scratch
+COPY --from=golang:1.15 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=golang:1.15 /usr/share/zoneinfo /usr/share/zoneinfo
 
 COPY --from=builder /omniscode-backend /bin/backend
 ENTRYPOINT [ "/bin/backend" ]


### PR DESCRIPTION
## このPRの概要
scratchイメージに足りないものを追加

## なぜこのPRが必要なのか
firebaseとの通信でSSL通信を行うときに証明書が必要なので
