### PR TITLE
コメントをIDで取得する処理の追加

### DIFF
--- a/controller/comment.go
+++ b/controller/comment.go
@@ -79,3 +79,30 @@ func (ctrl *CommentController) Create(c echo.Context) error {
 	}
 	return c.NoContent(http.StatusCreated)
 }
+
+// Get は GET /post/{postID}/comment/{commentID} のHandler
+func (ctrl *CommentController) Get(c echo.Context) error {
+	logger := log.New()
+	postID, err := strconv.Atoi(c.Param("postID"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest)
+	}
+	commentID, err := strconv.Atoi(c.Param("commentID"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest)
+	}
+
+	comment, err := ctrl.uc.Get(postID, commentID)
+
+	if err != nil {
+		errNF := &entity.ErrNotFound{}
+		if errors.As(err, errNF) {
+			return echo.NewHTTPError(http.StatusNotFound, errNF.Error())
+		}
+
+		logger.Errorf("Unexpected error GET /post/{postID}/comment/{commentID}: %s", err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
+	return c.JSON(http.StatusOK, comment)
+}

--- a/controller/comment_test.go
+++ b/controller/comment_test.go
@@ -296,3 +296,148 @@ func TestCommentController_Create(t *testing.T) {
 		})
 	}
 }
+
+func TestCommentController_Get(t *testing.T) {
+	tests := []struct {
+		name               string
+		postID             string
+		commentID          string
+		prepareMockComment func(comment *mock.MockComment)
+		wantErr            bool
+		wantCode           int
+		wantBody           string
+	}{
+		{
+			name:      "正しくコメントを取得できる",
+			postID:    "1",
+			commentID: "1",
+			prepareMockComment: func(comment *mock.MockComment) {
+				comment.EXPECT().FindByID(1, 1).Return(
+					&entity.Comment{
+						ID:        1,
+						UserID:    "userid1",
+						PostID:    1,
+						Type:      "highlight",
+						Content:   "content1",
+						FirstLine: 10,
+						LastLine:  12,
+						CreatedAt: "1970-01-01T09:01:40+09:00",
+						UpdatedAt: "1970-01-01T09:01:40+09:00",
+					}, nil)
+			},
+			wantErr:  false,
+			wantCode: 200,
+			wantBody: `{
+				"id": 1,
+				"user_id": "userid1",
+				"post_id": 1,
+				"type": "highlight",
+				"content": "content1",
+				"first_line": 10,
+				"last_line": 12,
+				"code": "",
+				"created_at": "1970-01-01T09:01:40+09:00",
+				"updated_at": "1970-01-01T09:01:40+09:00"
+			}`,
+		},
+		{
+			name:      "postIDが空ならBadRequest",
+			postID:    "",
+			commentID: "1",
+			prepareMockComment: func(comment *mock.MockComment) {
+			},
+			wantErr:  true,
+			wantCode: 400,
+			wantBody: "",
+		},
+		{
+			name:      "postIDが数値でないならBadRequest",
+			postID:    "a",
+			commentID: "1",
+			prepareMockComment: func(comment *mock.MockComment) {
+			},
+			wantErr:  true,
+			wantCode: 400,
+			wantBody: "",
+		},
+		{
+			name:      "commentIDが空ならBadRequest",
+			postID:    "1",
+			commentID: "",
+			prepareMockComment: func(comment *mock.MockComment) {
+			},
+			wantErr:  true,
+			wantCode: 400,
+			wantBody: "",
+		},
+		{
+			name:      "commentIDが数値でないならBadRequest",
+			postID:    "1",
+			commentID: "a",
+			prepareMockComment: func(comment *mock.MockComment) {
+			},
+			wantErr:  true,
+			wantCode: 400,
+			wantBody: "",
+		},
+		{
+			name:      "commentが存在しないならNotFound",
+			postID:    "1",
+			commentID: "1",
+			prepareMockComment: func(comment *mock.MockComment) {
+				comment.EXPECT().FindByID(1, 1).Return(
+					nil, entity.NewErrorNotFound("comment"))
+			},
+			wantErr:  true,
+			wantCode: 404,
+			wantBody: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("postID", "commentID")
+			c.SetParamValues(tt.postID, tt.commentID)
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			commentRepo := mock.NewMockComment(ctrl)
+			tt.prepareMockComment(commentRepo)
+			postRepo := mock.NewMockPost(ctrl)
+
+			con := NewCommentController(usecase.NewCommentUseCase(commentRepo, postRepo))
+			err := con.Get(c)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+
+			if he, ok := err.(*echo.HTTPError); ok {
+				if he.Code != tt.wantCode {
+					t.Errorf("code = %d, want = %d", he.Code, tt.wantCode)
+				}
+			} else {
+				if rec.Code != tt.wantCode {
+					t.Errorf("code = %d, want = %d", rec.Code, tt.wantCode)
+				}
+			}
+
+			if !tt.wantErr {
+				var gotBody, wantBody map[string]interface{}
+				if err = json.Unmarshal(rec.Body.Bytes(), &gotBody); err != nil {
+					t.Fatal(err)
+				}
+				if err = json.Unmarshal([]byte(tt.wantBody), &wantBody); err != nil {
+					t.Fatal(err)
+				}
+
+				if diff := cmp.Diff(wantBody, gotBody); diff != "" {
+					t.Errorf("body (-want +got) =\n%s\n", diff)
+				}
+			}
+		})
+	}
+}

--- a/infra/comment.go
+++ b/infra/comment.go
@@ -1,6 +1,8 @@
 package infra
 
 import (
+	"database/sql"
+	"errors"
 	"strings"
 	"time"
 
@@ -78,6 +80,30 @@ func (r *CommentRepository) Insert(comment *entity.Comment) error {
 		return err
 	}
 	return nil
+}
+
+// FindByID はpostID, commentIDからコメントを取得します
+func (r *CommentRepository) FindByID(postID, commentID int) (*entity.Comment, error) {
+	var commentDTO CommentDTO
+	if err := r.dbMap.SelectOne(&commentDTO, "SELECT * FROM comments WHERE post_id = ? AND id = ?", postID, commentID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, entity.NewErrorNotFound("comment")
+		}
+		return nil, err
+	}
+
+	return &entity.Comment{
+		ID:        commentDTO.ID,
+		UserID:    commentDTO.UserID,
+		PostID:    commentDTO.PostID,
+		Type:      commentDTO.Type,
+		Content:   commentDTO.Content,
+		FirstLine: commentDTO.FirstLine,
+		LastLine:  commentDTO.LastLine,
+		Code:      commentDTO.Code,
+		CreatedAt: service.ConvertTimeToStr(commentDTO.CreatedAt),
+		UpdatedAt: service.ConvertTimeToStr(commentDTO.UpdatedAt),
+	}, nil
 }
 
 // CommentDTO はDBとやり取りするためのDataTransferObject

--- a/infra/comment.go
+++ b/infra/comment.go
@@ -27,9 +27,9 @@ func NewCommentRepository(dbMap *gorp.DbMap) *CommentRepository {
 }
 
 // FindByPostID は該当PostIDに属するコメントのスライスを返す
-func (r *CommentRepository) FindByPostID(postid int) (comments []*entity.Comment, err error) {
+func (r *CommentRepository) FindByPostID(postID int) (comments []*entity.Comment, err error) {
 	var commentDTOs []CommentDTO
-	if _, err = r.dbMap.Select(&commentDTOs, "SELECT * FROM comments WHERE post_id = ?", postid); err != nil {
+	if _, err = r.dbMap.Select(&commentDTOs, "SELECT * FROM comments WHERE post_id = ?", postID); err != nil {
 		return nil, err
 	}
 	for _, commentDTO := range commentDTOs {

--- a/infra/comment_test.go
+++ b/infra/comment_test.go
@@ -273,3 +273,110 @@ func TestCommentRepository_Create(t *testing.T) {
 		})
 	}
 }
+
+func TestCommentRepository_FindByID(t *testing.T) {
+	dbMap, err := NewDB()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	dbMap.AddTableWithName(UserDTO{}, "users")
+	truncateTable(t, dbMap, "users")
+
+	if err := dbMap.Insert(&UserDTO{
+		ID:        "user-id",
+		Name:      "test user",
+		Profile:   "test profile",
+		TwitterID: "twitter",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	dbMap.AddTableWithName(PostDTO{}, "posts").SetKeys(true, "id")
+	truncateTable(t, dbMap, "posts")
+
+	if err := dbMap.Insert(&PostDTO{
+		ID:        1,
+		UserID:    "user-id",
+		Title:     "test title",
+		Code:      "package main\n\nimport \"fmt\"\n\nfunc main(){fmt.Println(\"This is test.\")}",
+		Language:  "Go",
+		Content:   "Test code",
+		Source:    "github.com",
+		CreatedAt: time.Unix(100, 0),
+		UpdatedAt: time.Unix(100, 0),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	dbMap.AddTableWithName(CommentDTO{}, "comments").SetKeys(true, "id")
+	truncateTable(t, dbMap, "comments")
+
+	if err := dbMap.Insert(&CommentDTO{
+		ID:        1,
+		UserID:    "user-id",
+		PostID:    1,
+		Type:      "none",
+		Content:   "type none",
+		CreatedAt: time.Unix(100, 0),
+		UpdatedAt: time.Unix(100, 0),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	commentRepo := NewCommentRepository(dbMap)
+
+	tests := []struct {
+		name        string
+		postID      int
+		commentID   int
+		wantComment *entity.Comment
+		wantErr     error
+	}{
+		{
+			name:      "正しくコメントを取得できる",
+			postID:    1,
+			commentID: 1,
+			wantComment: &entity.Comment{
+				ID:        1,
+				UserID:    "user-id",
+				PostID:    1,
+				Type:      "none",
+				Content:   "type none",
+				CreatedAt: "1970-01-01T00:01:40+09:00",
+				UpdatedAt: "1970-01-01T00:01:40+09:00",
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "PostIDが存在しなければErrNotFound",
+			postID:      100,
+			commentID:   1,
+			wantComment: nil,
+			wantErr:     entity.NewErrorNotFound("comment"),
+		},
+		{
+			name:        "CommentIDが存在しなければErrNotFound",
+			postID:      1,
+			commentID:   100,
+			wantComment: nil,
+			wantErr:     entity.NewErrorNotFound("comment"),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			gotComment, err := commentRepo.FindByID(tt.postID, tt.commentID)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantComment, gotComment); diff != "" {
+					t.Errorf("Data (-want +got) =\n%s\n", diff)
+				}
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 	comment := v1.Group("/post/:postID/comment")
 	comment.GET("", commentController.GetByPostID)
 	comment.POST("", commentController.Create, authMiddleware.Authenticate)
+	comment.GET("/:commentID", commentController.Get)
 
 	if err := e.Start(fmt.Sprintf(":%s", config.Port())); err != nil {
 		logger.Infof("shutting down the server with error' %s", err.Error())

--- a/repository/comment.go
+++ b/repository/comment.go
@@ -5,7 +5,7 @@ package repository
 import "github.com/openhacku-saboten/OmnisCode-backend/domain/entity"
 
 type Comment interface {
-	FindByPostID(postid int) (comments []*entity.Comment, err error)
+	FindByPostID(postID int) (comments []*entity.Comment, err error)
 	Insert(comment *entity.Comment) error
-	FindByID(postid, commentid int) (comment *entity.Comment, err error)
+	FindByID(postID, commentID int) (comment *entity.Comment, err error)
 }

--- a/repository/comment.go
+++ b/repository/comment.go
@@ -7,4 +7,5 @@ import "github.com/openhacku-saboten/OmnisCode-backend/domain/entity"
 type Comment interface {
 	FindByPostID(postid int) (comments []*entity.Comment, err error)
 	Insert(comment *entity.Comment) error
+	FindByID(postid, commentid int) (comment *entity.Comment, err error)
 }

--- a/usecase/comment.go
+++ b/usecase/comment.go
@@ -17,8 +17,8 @@ func NewCommentUseCase(comment repository.Comment, post repository.Post) *Commen
 	return &CommentUseCase{commentRepo: comment, postRepo: post}
 }
 
-func (u *CommentUseCase) GetByPostID(postid int) (comments []*entity.Comment, err error) {
-	comments, err = u.commentRepo.FindByPostID(postid)
+func (u *CommentUseCase) GetByPostID(postID int) (comments []*entity.Comment, err error) {
+	comments, err = u.commentRepo.FindByPostID(postID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetByPostID from DB: %w", err)
 	}
@@ -48,8 +48,8 @@ func (u *CommentUseCase) Create(ctx context.Context, comment *entity.Comment) er
 	return nil
 }
 
-func (u *CommentUseCase) Get(postid, commentid int) (comment *entity.Comment, err error) {
-	comment, err = u.commentRepo.FindByID(postid, commentid)
+func (u *CommentUseCase) Get(postID, commentID int) (comment *entity.Comment, err error) {
+	comment, err = u.commentRepo.FindByID(postID, commentID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get comment from DB: %w", err)
 	}

--- a/usecase/comment.go
+++ b/usecase/comment.go
@@ -47,3 +47,11 @@ func (u *CommentUseCase) Create(ctx context.Context, comment *entity.Comment) er
 	}
 	return nil
 }
+
+func (u *CommentUseCase) Get(postid, commentid int) (comment *entity.Comment, err error) {
+	comment, err = u.commentRepo.FindByID(postid, commentid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Get comment from DB: %w", err)
+	}
+	return
+}

--- a/usecase/mock/mock_comment.go
+++ b/usecase/mock/mock_comment.go
@@ -35,33 +35,33 @@ func (m *MockComment) EXPECT() *MockCommentMockRecorder {
 }
 
 // FindByID mocks base method.
-func (m *MockComment) FindByID(postid, commentid int) (*entity.Comment, error) {
+func (m *MockComment) FindByID(postID, commentID int) (*entity.Comment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindByID", postid, commentid)
+	ret := m.ctrl.Call(m, "FindByID", postID, commentID)
 	ret0, _ := ret[0].(*entity.Comment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindByID indicates an expected call of FindByID.
-func (mr *MockCommentMockRecorder) FindByID(postid, commentid interface{}) *gomock.Call {
+func (mr *MockCommentMockRecorder) FindByID(postID, commentID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockComment)(nil).FindByID), postid, commentid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockComment)(nil).FindByID), postID, commentID)
 }
 
 // FindByPostID mocks base method.
-func (m *MockComment) FindByPostID(postid int) ([]*entity.Comment, error) {
+func (m *MockComment) FindByPostID(postID int) ([]*entity.Comment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindByPostID", postid)
+	ret := m.ctrl.Call(m, "FindByPostID", postID)
 	ret0, _ := ret[0].([]*entity.Comment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindByPostID indicates an expected call of FindByPostID.
-func (mr *MockCommentMockRecorder) FindByPostID(postid interface{}) *gomock.Call {
+func (mr *MockCommentMockRecorder) FindByPostID(postID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByPostID", reflect.TypeOf((*MockComment)(nil).FindByPostID), postid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByPostID", reflect.TypeOf((*MockComment)(nil).FindByPostID), postID)
 }
 
 // Insert mocks base method.

--- a/usecase/mock/mock_comment.go
+++ b/usecase/mock/mock_comment.go
@@ -34,6 +34,21 @@ func (m *MockComment) EXPECT() *MockCommentMockRecorder {
 	return m.recorder
 }
 
+// FindByID mocks base method.
+func (m *MockComment) FindByID(postid, commentid int) (*entity.Comment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByID", postid, commentid)
+	ret0, _ := ret[0].(*entity.Comment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByID indicates an expected call of FindByID.
+func (mr *MockCommentMockRecorder) FindByID(postid, commentid interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockComment)(nil).FindByID), postid, commentid)
+}
+
 // FindByPostID mocks base method.
 func (m *MockComment) FindByPostID(postid int) ([]*entity.Comment, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## このPRの概要
```GET /api/v1/post/{postID}/comment/{commentID}```に対応するAPIの追加

## なぜこのPRが必要なのか
コメントの詳細画面を表示する際に必要

refer: #34