### PR TITLE
feat: リクエストが切れた時にDB操作も即時終了するような機能追加

### DIFF
--- a/controller/comment.go
+++ b/controller/comment.go
@@ -30,7 +30,7 @@ func (ctrl *CommentController) GetByPostID(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest)
 	}
 
-	comments, err := ctrl.uc.GetByPostID(postID)
+	comments, err := ctrl.uc.GetByPostID(c.Request().Context(), postID)
 
 	if err != nil {
 		errNF := &entity.ErrNotFound{}
@@ -95,7 +95,7 @@ func (ctrl *CommentController) Get(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest)
 	}
 
-	comment, err := ctrl.uc.Get(postID, commentID)
+	comment, err := ctrl.uc.Get(c.Request().Context(), postID, commentID)
 
 	if err != nil {
 		errNF := &entity.ErrNotFound{}

--- a/controller/comment_test.go
+++ b/controller/comment_test.go
@@ -27,7 +27,7 @@ func TestCommentController_GetByPostID(t *testing.T) {
 			name:   "正しくコメントを取得できる",
 			postID: "1",
 			prepareMockComment: func(comment *mock.MockComment) {
-				comment.EXPECT().FindByPostID(1).Return(
+				comment.EXPECT().FindByPostID(gomock.Any(), 1).Return(
 					[]*entity.Comment{
 						{
 							ID:        1,
@@ -108,7 +108,7 @@ func TestCommentController_GetByPostID(t *testing.T) {
 			name:   "取得したコメント数が0ならErrNotFound",
 			postID: "100",
 			prepareMockComment: func(comment *mock.MockComment) {
-				comment.EXPECT().FindByPostID(100).Return(
+				comment.EXPECT().FindByPostID(gomock.Any(), 100).Return(
 					nil, entity.NewErrorNotFound("comment"),
 				)
 			},
@@ -189,6 +189,7 @@ func TestCommentController_Create(t *testing.T) {
 			}`,
 			prepareMockComment: func(comment *mock.MockComment) {
 				comment.EXPECT().Insert(
+					gomock.Any(),
 					&entity.Comment{
 						UserID:    "user-id",
 						PostID:    1,
@@ -315,7 +316,7 @@ func TestCommentController_Get(t *testing.T) {
 			postID:    "1",
 			commentID: "1",
 			prepareMockComment: func(comment *mock.MockComment) {
-				comment.EXPECT().FindByID(1, 1).Return(
+				comment.EXPECT().FindByID(gomock.Any(), 1, 1).Return(
 					&entity.Comment{
 						ID:        1,
 						UserID:    "userid1",
@@ -388,7 +389,7 @@ func TestCommentController_Get(t *testing.T) {
 			postID:    "1",
 			commentID: "1",
 			prepareMockComment: func(comment *mock.MockComment) {
-				comment.EXPECT().FindByID(1, 1).Return(
+				comment.EXPECT().FindByID(gomock.Any(), 1, 1).Return(
 					nil, entity.NewErrorNotFound("comment"))
 			},
 			wantErr:  true,

--- a/controller/user.go
+++ b/controller/user.go
@@ -106,7 +106,7 @@ func (ctrl *UserController) Create(c echo.Context) error {
 	}
 	user.ID = userID
 
-	if err := ctrl.uc.Create(user); err != nil {
+	if err := ctrl.uc.Create(c.Request().Context(), user); err != nil {
 		if errors.Is(err, entity.ErrDuplicatedUser) {
 			return echo.NewHTTPError(http.StatusBadRequest, entity.ErrDuplicatedUser.Error())
 		}
@@ -138,7 +138,7 @@ func (ctrl *UserController) Update(c echo.Context) error {
 	}
 	user.ID = userID
 
-	if err := ctrl.uc.Update(user); err != nil {
+	if err := ctrl.uc.Update(c.Request().Context(), user); err != nil {
 		if errors.Is(err, entity.ErrUserNotFound) {
 			return echo.NewHTTPError(http.StatusNotFound, entity.ErrUserNotFound.Error())
 		}

--- a/controller/user_test.go
+++ b/controller/user_test.go
@@ -30,7 +30,7 @@ func TestUserController_Get(t *testing.T) {
 			name:   "正しくユーザーを取得できる",
 			userID: "user-id",
 			prepareMockUser: func(user *mock.MockUser) {
-				user.EXPECT().FindByID("user-id").Return(
+				user.EXPECT().FindByID(gomock.Any(), "user-id").Return(
 					entity.NewUser("user-id", "name", "profile", "twitter", ""),
 					nil,
 				)
@@ -52,7 +52,7 @@ func TestUserController_Get(t *testing.T) {
 			name:   "存在しないユーザーIDならErrUserNotFound",
 			userID: "invalid-user-id",
 			prepareMockUser: func(user *mock.MockUser) {
-				user.EXPECT().FindByID("invalid-user-id").Return(
+				user.EXPECT().FindByID(gomock.Any(), "invalid-user-id").Return(
 					nil,
 					entity.ErrUserNotFound,
 				)
@@ -395,6 +395,7 @@ func TestUserController_Create(t *testing.T) {
 			}`,
 			prepareMockUser: func(user *mock.MockUser) {
 				user.EXPECT().Insert(
+					gomock.Any(),
 					entity.NewUser("user-id", "username", "profile", "twitter", ""),
 				).Return(nil)
 			},
@@ -411,6 +412,7 @@ func TestUserController_Create(t *testing.T) {
 			}`,
 			prepareMockUser: func(user *mock.MockUser) {
 				user.EXPECT().Insert(
+					gomock.Any(),
 					entity.NewUser("user-id", "username", "profile", "twitter", ""),
 				).Return(nil)
 			},
@@ -445,6 +447,7 @@ func TestUserController_Create(t *testing.T) {
 			}`,
 			prepareMockUser: func(user *mock.MockUser) {
 				user.EXPECT().Insert(
+					gomock.Any(),
 					entity.NewUser("user-id", "username", "profile", "twitter", ""),
 				).Return(entity.ErrDuplicatedUser)
 			},
@@ -461,6 +464,7 @@ func TestUserController_Create(t *testing.T) {
 			}`,
 			prepareMockUser: func(user *mock.MockUser) {
 				user.EXPECT().Insert(
+					gomock.Any(),
 					entity.NewUser("user-id", "username", "profile", "twitter", ""),
 				).Return(entity.ErrDuplicatedTwitterID)
 			},
@@ -524,11 +528,12 @@ func TestUserController_Update(t *testing.T) {
 				"twitter_id":"newtwitter"
 			}`,
 			prepareMockUser: func(user *mock.MockUser) {
-				user.EXPECT().FindByID("user-id").Return(
+				user.EXPECT().FindByID(gomock.Any(), "user-id").Return(
 					entity.NewUser("user-id", "name", "profile", "twitter", ""),
 					nil,
 				)
 				user.EXPECT().Update(
+					gomock.Any(),
 					entity.NewUser("user-id", "newname", "newprofile", "newtwitter", ""),
 				).Return(nil)
 			},
@@ -544,11 +549,12 @@ func TestUserController_Update(t *testing.T) {
 				"twitter_id":"@newtwitter"
 			}`,
 			prepareMockUser: func(user *mock.MockUser) {
-				user.EXPECT().FindByID("user-id").Return(
+				user.EXPECT().FindByID(gomock.Any(), "user-id").Return(
 					entity.NewUser("user-id", "name", "profile", "twitter", ""),
 					nil,
 				)
 				user.EXPECT().Update(
+					gomock.Any(),
 					entity.NewUser("user-id", "newname", "newprofile", "newtwitter", ""),
 				).Return(nil)
 			},
@@ -582,7 +588,7 @@ func TestUserController_Update(t *testing.T) {
 				"twitter_id":"twitter"
 			}`,
 			prepareMockUser: func(user *mock.MockUser) {
-				user.EXPECT().FindByID("invalid-user-id").Return(
+				user.EXPECT().FindByID(gomock.Any(), "invalid-user-id").Return(
 					nil,
 					entity.ErrUserNotFound,
 				)
@@ -600,11 +606,12 @@ func TestUserController_Update(t *testing.T) {
 				"twitter_id":"newtwitter"
 			}`,
 			prepareMockUser: func(user *mock.MockUser) {
-				user.EXPECT().FindByID("user-id").Return(
+				user.EXPECT().FindByID(gomock.Any(), "user-id").Return(
 					entity.NewUser("user-id", "name", "profile", "twitter", ""),
 					nil,
 				)
 				user.EXPECT().Update(
+					gomock.Any(),
 					entity.NewUser("user-id", "newname", "newprofile", "newtwitter", ""),
 				).Return(entity.NewErrorDuplicated("user TwitterID"))
 			},

--- a/infra/comment.go
+++ b/infra/comment.go
@@ -31,112 +31,132 @@ func NewCommentRepository(dbMap *gorp.DbMap) *CommentRepository {
 }
 
 // FindByPostID は該当PostIDに属するコメントのスライスを返す
-func (r *CommentRepository) FindByPostID(postID int) (comments []*entity.Comment, err error) {
-	var commentDTOs []CommentDTO
-	if _, err = r.dbMap.Select(&commentDTOs, "SELECT * FROM comments WHERE post_id = ?", postID); err != nil {
-		return nil, fmt.Errorf("failed CommentRepository.FindByPostID: %w", err)
-	}
-	for _, commentDTO := range commentDTOs {
-		comment := &entity.Comment{
-			ID:        commentDTO.ID,
-			UserID:    commentDTO.UserID,
-			PostID:    commentDTO.PostID,
-			Type:      commentDTO.Type,
-			Content:   commentDTO.Content,
-			FirstLine: commentDTO.FirstLine,
-			LastLine:  commentDTO.LastLine,
-			Code:      commentDTO.Code,
-			CreatedAt: service.ConvertTimeToStr(commentDTO.CreatedAt),
-			UpdatedAt: service.ConvertTimeToStr(commentDTO.UpdatedAt),
+func (r *CommentRepository) FindByPostID(ctx context.Context, postID int) (comments []*entity.Comment, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		var commentDTOs []CommentDTO
+		if _, err = r.dbMap.Select(&commentDTOs, "SELECT * FROM comments WHERE post_id = ?", postID); err != nil {
+			return nil, fmt.Errorf("failed CommentRepository.FindByPostID: %w", err)
 		}
-		comments = append(comments, comment)
+		for _, commentDTO := range commentDTOs {
+			comment := &entity.Comment{
+				ID:        commentDTO.ID,
+				UserID:    commentDTO.UserID,
+				PostID:    commentDTO.PostID,
+				Type:      commentDTO.Type,
+				Content:   commentDTO.Content,
+				FirstLine: commentDTO.FirstLine,
+				LastLine:  commentDTO.LastLine,
+				Code:      commentDTO.Code,
+				CreatedAt: service.ConvertTimeToStr(commentDTO.CreatedAt),
+				UpdatedAt: service.ConvertTimeToStr(commentDTO.UpdatedAt),
+			}
+			comments = append(comments, comment)
+		}
+		if comments == nil {
+			return nil, entity.NewErrorNotFound("comment")
+		}
+		return
 	}
-	if comments == nil {
-		return nil, entity.NewErrorNotFound("comment")
-	}
-	return
 }
 
 // FindByUserID は該当IDのユーザのコメントをDBから取得して返す
 func (r *CommentRepository) FindByUserID(ctx context.Context, uid string) ([]*entity.Comment, error) {
-	var commentDTOs []CommentDTO
-	if _, err := r.dbMap.Select(&commentDTOs, "SELECT * FROM comments WHERE user_id = ?", uid); err != nil {
-		return nil, err
-	}
-
-	var comments []*entity.Comment
-	for _, commentDTO := range commentDTOs {
-		comment := &entity.Comment{
-			ID:        commentDTO.ID,
-			UserID:    commentDTO.UserID,
-			PostID:    commentDTO.PostID,
-			Type:      commentDTO.Type,
-			Content:   commentDTO.Content,
-			FirstLine: commentDTO.FirstLine,
-			LastLine:  commentDTO.LastLine,
-			Code:      commentDTO.Code,
-			CreatedAt: service.ConvertTimeToStr(commentDTO.CreatedAt),
-			UpdatedAt: service.ConvertTimeToStr(commentDTO.UpdatedAt),
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		var commentDTOs []CommentDTO
+		if _, err := r.dbMap.Select(&commentDTOs, "SELECT * FROM comments WHERE user_id = ?", uid); err != nil {
+			return nil, err
 		}
-		comments = append(comments, comment)
+
+		var comments []*entity.Comment
+		for _, commentDTO := range commentDTOs {
+			comment := &entity.Comment{
+				ID:        commentDTO.ID,
+				UserID:    commentDTO.UserID,
+				PostID:    commentDTO.PostID,
+				Type:      commentDTO.Type,
+				Content:   commentDTO.Content,
+				FirstLine: commentDTO.FirstLine,
+				LastLine:  commentDTO.LastLine,
+				Code:      commentDTO.Code,
+				CreatedAt: service.ConvertTimeToStr(commentDTO.CreatedAt),
+				UpdatedAt: service.ConvertTimeToStr(commentDTO.UpdatedAt),
+			}
+			comments = append(comments, comment)
+		}
+		if comments == nil {
+			return nil, entity.NewErrorNotFound("comment")
+		}
+		return comments, nil
 	}
-	if comments == nil {
-		return nil, entity.NewErrorNotFound("comment")
-	}
-	return comments, nil
 }
 
 // Insert は該当ユーザーをDBに保存する
-func (r *CommentRepository) Insert(comment *entity.Comment) error {
-	commentDTO := &CommentInsertDTO{
-		ID:        comment.ID,
-		UserID:    comment.UserID,
-		PostID:    comment.PostID,
-		Type:      comment.Type,
-		Content:   comment.Content,
-		FirstLine: comment.FirstLine,
-		LastLine:  comment.LastLine,
-		Code:      comment.Code,
-	}
-
-	if err := r.dbMap.Insert(commentDTO); err != nil {
-		if sqlerr, ok := err.(*mysql.MySQLError); ok {
-			// 存在しないPostIDで登録した時のエラー
-			if sqlerr.Number == mysqlerr.ER_NO_REFERENCED_ROW_2 && strings.Contains(sqlerr.Message, "post_id") {
-				return entity.NewErrorNotFound("post")
-			}
-			// 存在しないUserIDで登録した時のエラー
-			if sqlerr.Number == mysqlerr.ER_NO_REFERENCED_ROW_2 && strings.Contains(sqlerr.Message, "user_id") {
-				return entity.NewErrorNotFound("user")
-			}
+func (r *CommentRepository) Insert(ctx context.Context, comment *entity.Comment) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		commentDTO := &CommentInsertDTO{
+			ID:        comment.ID,
+			UserID:    comment.UserID,
+			PostID:    comment.PostID,
+			Type:      comment.Type,
+			Content:   comment.Content,
+			FirstLine: comment.FirstLine,
+			LastLine:  comment.LastLine,
+			Code:      comment.Code,
 		}
-		return err
+
+		if err := r.dbMap.Insert(commentDTO); err != nil {
+			if sqlerr, ok := err.(*mysql.MySQLError); ok {
+				// 存在しないPostIDで登録した時のエラー
+				if sqlerr.Number == mysqlerr.ER_NO_REFERENCED_ROW_2 && strings.Contains(sqlerr.Message, "post_id") {
+					return entity.NewErrorNotFound("post")
+				}
+				// 存在しないUserIDで登録した時のエラー
+				if sqlerr.Number == mysqlerr.ER_NO_REFERENCED_ROW_2 && strings.Contains(sqlerr.Message, "user_id") {
+					return entity.NewErrorNotFound("user")
+				}
+			}
+			return err
+		}
 	}
 	return nil
 }
 
 // FindByID はpostID, commentIDからコメントを取得します
-func (r *CommentRepository) FindByID(postID, commentID int) (*entity.Comment, error) {
-	var commentDTO CommentDTO
-	if err := r.dbMap.SelectOne(&commentDTO, "SELECT * FROM comments WHERE post_id = ? AND id = ?", postID, commentID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, entity.NewErrorNotFound("comment")
+func (r *CommentRepository) FindByID(ctx context.Context, postID, commentID int) (*entity.Comment, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		var commentDTO CommentDTO
+		if err := r.dbMap.SelectOne(&commentDTO, "SELECT * FROM comments WHERE post_id = ? AND id = ?", postID, commentID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, entity.NewErrorNotFound("comment")
+			}
+			return nil, err
 		}
-		return nil, err
-	}
 
-	return &entity.Comment{
-		ID:        commentDTO.ID,
-		UserID:    commentDTO.UserID,
-		PostID:    commentDTO.PostID,
-		Type:      commentDTO.Type,
-		Content:   commentDTO.Content,
-		FirstLine: commentDTO.FirstLine,
-		LastLine:  commentDTO.LastLine,
-		Code:      commentDTO.Code,
-		CreatedAt: service.ConvertTimeToStr(commentDTO.CreatedAt),
-		UpdatedAt: service.ConvertTimeToStr(commentDTO.UpdatedAt),
-	}, nil
+		return &entity.Comment{
+			ID:        commentDTO.ID,
+			UserID:    commentDTO.UserID,
+			PostID:    commentDTO.PostID,
+			Type:      commentDTO.Type,
+			Content:   commentDTO.Content,
+			FirstLine: commentDTO.FirstLine,
+			LastLine:  commentDTO.LastLine,
+			Code:      commentDTO.Code,
+			CreatedAt: service.ConvertTimeToStr(commentDTO.CreatedAt),
+			UpdatedAt: service.ConvertTimeToStr(commentDTO.UpdatedAt),
+		}, nil
+	}
 }
 
 // CommentDTO はDBとやり取りするためのDataTransferObject

--- a/infra/comment.go
+++ b/infra/comment.go
@@ -126,8 +126,8 @@ func (r *CommentRepository) Insert(ctx context.Context, comment *entity.Comment)
 			}
 			return err
 		}
+		return nil
 	}
-	return nil
 }
 
 // FindByID はpostID, commentIDからコメントを取得します

--- a/infra/comment_test.go
+++ b/infra/comment_test.go
@@ -143,7 +143,8 @@ func TestCommentRepository_FindByPostID(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotComments, err := commentRepo.FindByPostID(tt.postID)
+			ctx := context.Background()
+			gotComments, err := commentRepo.FindByPostID(ctx, tt.postID)
 
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)
@@ -418,7 +419,8 @@ func TestCommentRepository_Create(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			err := commentRepo.Insert(tt.comment)
+			ctx := context.Background()
+			err := commentRepo.Insert(ctx, tt.comment)
 
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)
@@ -520,7 +522,7 @@ func TestCommentRepository_FindByID(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotComment, err := commentRepo.FindByID(tt.postID, tt.commentID)
+			gotComment, err := commentRepo.FindByID(context.Background(), tt.postID, tt.commentID)
 
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)

--- a/infra/post.go
+++ b/infra/post.go
@@ -153,8 +153,8 @@ func (p *PostRepository) Insert(ctx context.Context, post *entity.Post) error {
 			}
 			return err
 		}
+		return nil
 	}
-	return nil
 }
 
 // PostDTO はDBとやりとりするためのDataTransferObjectです

--- a/infra/post.go
+++ b/infra/post.go
@@ -31,111 +31,129 @@ func NewPostRepository(dbMap *gorp.DbMap) *PostRepository {
 }
 
 // GetAll はMySQLサーバに接続して、全てのPostを取得して返すメソッドです
-func (p *PostRepository) GetAll(context.Context) ([]*entity.Post, error) {
-	var postDTOs []PostDTO
-	if _, err := p.dbMap.Select(&postDTOs, "SELECT * FROM posts"); err != nil {
-		return nil, fmt.Errorf("failed PostRepository.GetAll: %w", err)
-	}
+func (p *PostRepository) GetAll(ctx context.Context) ([]*entity.Post, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		var postDTOs []PostDTO
+		if _, err := p.dbMap.Select(&postDTOs, "SELECT * FROM posts"); err != nil {
+			return nil, fmt.Errorf("failed PostRepository.GetAll: %w", err)
+		}
 
-	var posts []*entity.Post
-	for _, dto := range postDTOs {
-		posts = append(posts, &entity.Post{
-			ID:        dto.ID,
-			UserID:    dto.UserID,
-			Title:     dto.Title,
-			Code:      dto.Code,
-			Language:  dto.Language,
-			Content:   dto.Content,
-			Source:    dto.Source,
-			CreatedAt: service.ConvertTimeToStr(dto.CreatedAt),
-			UpdatedAt: service.ConvertTimeToStr(dto.UpdatedAt),
-		})
+		var posts []*entity.Post
+		for _, dto := range postDTOs {
+			posts = append(posts, &entity.Post{
+				ID:        dto.ID,
+				UserID:    dto.UserID,
+				Title:     dto.Title,
+				Code:      dto.Code,
+				Language:  dto.Language,
+				Content:   dto.Content,
+				Source:    dto.Source,
+				CreatedAt: service.ConvertTimeToStr(dto.CreatedAt),
+				UpdatedAt: service.ConvertTimeToStr(dto.UpdatedAt),
+			})
+		}
+		if posts == nil {
+			return nil, entity.NewErrorNotFound("post")
+		}
+		return posts, nil
 	}
-	if posts == nil {
-		return nil, entity.NewErrorNotFound("post")
-	}
-
-	return posts, nil
 }
 
 // FindByID はpostIDから投稿を取得します
 func (p *PostRepository) FindByID(ctx context.Context, postID int) (*entity.Post, error) {
-	var postDTO PostDTO
-	if err := p.dbMap.SelectOne(&postDTO, "SELECT * FROM posts WHERE id = ?", postID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, entity.NewErrorNotFound("post")
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		var postDTO PostDTO
+		if err := p.dbMap.SelectOne(&postDTO, "SELECT * FROM posts WHERE id = ?", postID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, entity.NewErrorNotFound("post")
+			}
+			return nil, err
 		}
-		return nil, err
-	}
 
-	return &entity.Post{
-		ID:        postDTO.ID,
-		UserID:    postDTO.UserID,
-		Title:     postDTO.Title,
-		Code:      postDTO.Title,
-		Language:  postDTO.Language,
-		Content:   postDTO.Content,
-		Source:    postDTO.Source,
-		CreatedAt: service.ConvertTimeToStr(postDTO.CreatedAt),
-		UpdatedAt: service.ConvertTimeToStr(postDTO.UpdatedAt),
-	}, nil
+		return &entity.Post{
+			ID:        postDTO.ID,
+			UserID:    postDTO.UserID,
+			Title:     postDTO.Title,
+			Code:      postDTO.Title,
+			Language:  postDTO.Language,
+			Content:   postDTO.Content,
+			Source:    postDTO.Source,
+			CreatedAt: service.ConvertTimeToStr(postDTO.CreatedAt),
+			UpdatedAt: service.ConvertTimeToStr(postDTO.UpdatedAt),
+		}, nil
+	}
 }
 
 // FindByUserID はユーザの投稿をDBから取得します
 func (p *PostRepository) FindByUserID(ctx context.Context, uid string) ([]*entity.Post, error) {
-	var postDTOs []PostDTO
-	if _, err := p.dbMap.Select(&postDTOs, "SELECT * FROM posts WHERE user_id = ?", uid); err != nil {
-		return nil, fmt.Errorf("failed PostRepository.FindByUserID: %w", err)
-	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		var postDTOs []PostDTO
+		if _, err := p.dbMap.Select(&postDTOs, "SELECT * FROM posts WHERE user_id = ?", uid); err != nil {
+			return nil, fmt.Errorf("failed PostRepository.FindByUserID: %w", err)
+		}
 
-	var posts []*entity.Post
+		var posts []*entity.Post
 
-	for _, dto := range postDTOs {
-		posts = append(posts, &entity.Post{
-			ID:        dto.ID,
-			UserID:    dto.UserID,
-			Title:     dto.Title,
-			Code:      dto.Code,
-			Language:  dto.Language,
-			Content:   dto.Content,
-			Source:    dto.Source,
-			CreatedAt: service.ConvertTimeToStr(dto.CreatedAt),
-			UpdatedAt: service.ConvertTimeToStr(dto.UpdatedAt),
-		})
-	}
-	if posts == nil {
-		return nil, entity.NewErrorNotFound("post")
-	}
+		for _, dto := range postDTOs {
+			posts = append(posts, &entity.Post{
+				ID:        dto.ID,
+				UserID:    dto.UserID,
+				Title:     dto.Title,
+				Code:      dto.Code,
+				Language:  dto.Language,
+				Content:   dto.Content,
+				Source:    dto.Source,
+				CreatedAt: service.ConvertTimeToStr(dto.CreatedAt),
+				UpdatedAt: service.ConvertTimeToStr(dto.UpdatedAt),
+			})
+		}
+		if posts == nil {
+			return nil, entity.NewErrorNotFound("post")
+		}
 
-	return posts, nil
+		return posts, nil
+	}
 }
 
 // Insert は引数で渡したエンティティの投稿をDBに保存します
 func (p *PostRepository) Insert(ctx context.Context, post *entity.Post) error {
-	postDTO := &PostInsertDTO{
-		ID:       post.ID,
-		UserID:   post.UserID,
-		Title:    post.Title,
-		Code:     post.Code,
-		Language: post.Language,
-		Content:  post.Content,
-		Source:   post.Source,
-	}
-
-	if err := p.dbMap.Insert(postDTO); err != nil {
-		if sqlerr, ok := err.(*mysql.MySQLError); ok {
-			// 存在しないユーザIDで登録した時のエラー
-			if sqlerr.Number == mysqlerr.ER_NO_REFERENCED_ROW_2 && strings.Contains(sqlerr.Message, "user_id") {
-				return errors.New("unexisted user")
-			}
-			// postIDが重複したときのエラー
-			if sqlerr.Number == mysqlerr.ER_DUP_ENTRY && strings.Contains(sqlerr.Message, "posts.PRIMARY") {
-				return errors.New("post ID is duplicated")
-			}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		postDTO := &PostInsertDTO{
+			ID:       post.ID,
+			UserID:   post.UserID,
+			Title:    post.Title,
+			Code:     post.Code,
+			Language: post.Language,
+			Content:  post.Content,
+			Source:   post.Source,
 		}
-		return err
-	}
 
+		if err := p.dbMap.Insert(postDTO); err != nil {
+			if sqlerr, ok := err.(*mysql.MySQLError); ok {
+				// 存在しないユーザIDで登録した時のエラー
+				if sqlerr.Number == mysqlerr.ER_NO_REFERENCED_ROW_2 && strings.Contains(sqlerr.Message, "user_id") {
+					return errors.New("unexisted user")
+				}
+				// postIDが重複したときのエラー
+				if sqlerr.Number == mysqlerr.ER_DUP_ENTRY && strings.Contains(sqlerr.Message, "posts.PRIMARY") {
+					return errors.New("post ID is duplicated")
+				}
+			}
+			return err
+		}
+	}
 	return nil
 }
 

--- a/infra/user.go
+++ b/infra/user.go
@@ -103,8 +103,8 @@ func (r *UserRepository) Update(ctx context.Context, user *entity.User) error {
 			}
 			return err
 		}
+		return nil
 	}
-	return nil
 }
 
 // UserDTO はDBとやり取りするためのDataTransferObject

--- a/infra/user.go
+++ b/infra/user.go
@@ -1,6 +1,7 @@
 package infra
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"strings"
@@ -26,67 +27,82 @@ func NewUserRepository(dbMap *gorp.DbMap) *UserRepository {
 }
 
 // FindByID は該当IDのユーザーの情報をDBから取得して返す
-func (r *UserRepository) FindByID(uid string) (user *entity.User, err error) {
-	var userDTO UserDTO
-	err = r.dbMap.SelectOne(&userDTO, "SELECT * FROM users WHERE id = ?", uid)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, entity.ErrUserNotFound
+func (r *UserRepository) FindByID(ctx context.Context, uid string) (user *entity.User, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		var userDTO UserDTO
+		err = r.dbMap.SelectOne(&userDTO, "SELECT * FROM users WHERE id = ?", uid)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, entity.ErrUserNotFound
+			}
+			return nil, err
 		}
-		return nil, err
+		user = entity.NewUser(
+			userDTO.ID,
+			userDTO.Name,
+			userDTO.Profile,
+			userDTO.TwitterID,
+			"",
+		)
+		return
 	}
-	user = entity.NewUser(
-		userDTO.ID,
-		userDTO.Name,
-		userDTO.Profile,
-		userDTO.TwitterID,
-		"",
-	)
-	return
 }
 
 // Insert は該当ユーザーをDBに保存する
-func (r *UserRepository) Insert(user *entity.User) error {
-	userDTO := &UserDTO{
-		ID:        user.ID,
-		Name:      user.Name,
-		Profile:   user.Profile,
-		TwitterID: user.TwitterID,
-	}
-
-	if err := r.dbMap.Insert(userDTO); err != nil {
-		if sqlerr, ok := err.(*mysql.MySQLError); ok {
-			// userIDが重複したときのエラー
-			if sqlerr.Number == mysqlerr.ER_DUP_ENTRY && strings.Contains(sqlerr.Message, "users.PRIMARY") {
-				return entity.ErrDuplicatedUser
-			}
-			// twitterIDが重複したときのエラー
-			if sqlerr.Number == mysqlerr.ER_DUP_ENTRY && strings.Contains(sqlerr.Message, "twitter_id") {
-				return entity.ErrDuplicatedTwitterID
-			}
+func (r *UserRepository) Insert(ctx context.Context, user *entity.User) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		userDTO := &UserDTO{
+			ID:        user.ID,
+			Name:      user.Name,
+			Profile:   user.Profile,
+			TwitterID: user.TwitterID,
 		}
-		return err
+
+		if err := r.dbMap.Insert(userDTO); err != nil {
+			if sqlerr, ok := err.(*mysql.MySQLError); ok {
+				// userIDが重複したときのエラー
+				if sqlerr.Number == mysqlerr.ER_DUP_ENTRY && strings.Contains(sqlerr.Message, "users.PRIMARY") {
+					return entity.ErrDuplicatedUser
+				}
+				// twitterIDが重複したときのエラー
+				if sqlerr.Number == mysqlerr.ER_DUP_ENTRY && strings.Contains(sqlerr.Message, "twitter_id") {
+					return entity.ErrDuplicatedTwitterID
+				}
+			}
+			return err
+		}
+		return nil
 	}
-	return nil
 }
 
 // Update は該当ユーザーをDBに保存する
-func (r *UserRepository) Update(user *entity.User) error {
-	userDTO := &UserDTO{
-		ID:        user.ID,
-		Name:      user.Name,
-		Profile:   user.Profile,
-		TwitterID: user.TwitterID,
-	}
-
-	if _, err := r.dbMap.Update(userDTO); err != nil {
-		if sqlerr, ok := err.(*mysql.MySQLError); ok {
-			// twitterIDが重複したときのエラー
-			if sqlerr.Number == mysqlerr.ER_DUP_ENTRY && strings.Contains(sqlerr.Message, "twitter_id") {
-				return entity.NewErrorDuplicated("user TwitterID")
-			}
+func (r *UserRepository) Update(ctx context.Context, user *entity.User) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		userDTO := &UserDTO{
+			ID:        user.ID,
+			Name:      user.Name,
+			Profile:   user.Profile,
+			TwitterID: user.TwitterID,
 		}
-		return err
+
+		if _, err := r.dbMap.Update(userDTO); err != nil {
+			if sqlerr, ok := err.(*mysql.MySQLError); ok {
+				// twitterIDが重複したときのエラー
+				if sqlerr.Number == mysqlerr.ER_DUP_ENTRY && strings.Contains(sqlerr.Message, "twitter_id") {
+					return entity.NewErrorDuplicated("user TwitterID")
+				}
+			}
+			return err
+		}
 	}
 	return nil
 }

--- a/infra/user_test.go
+++ b/infra/user_test.go
@@ -1,6 +1,7 @@
 package infra
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -50,7 +51,7 @@ func TestUserRepository_FindByID(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotUser, err := userRepo.FindByID(tt.userID)
+			gotUser, err := userRepo.FindByID(context.Background(), tt.userID)
 
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)
@@ -108,7 +109,7 @@ func TestUserRepository_Insert(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			err := userRepo.Insert(tt.user)
+			err := userRepo.Insert(context.Background(), tt.user)
 
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)
@@ -176,7 +177,7 @@ func TestUserRepository_Update(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			err := userRepo.Update(tt.user)
+			err := userRepo.Update(context.Background(), tt.user)
 
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)

--- a/repository/comment.go
+++ b/repository/comment.go
@@ -10,8 +10,8 @@ import (
 
 // Comment はコメントに関する永続化と再構築のためのリポジトリです
 type Comment interface {
+	FindByID(ctx context.Context, postID, commentID int) (comment *entity.Comment, err error)
 	FindByUserID(ctx context.Context, uid string) ([]*entity.Comment, error)
-	FindByPostID(postID int) (comments []*entity.Comment, err error)
-	Insert(comment *entity.Comment) error
-	FindByID(postID, commentID int) (comment *entity.Comment, err error)
+	FindByPostID(ctx context.Context, postID int) (comments []*entity.Comment, err error)
+	Insert(ctx context.Context, comment *entity.Comment) error
 }

--- a/repository/user.go
+++ b/repository/user.go
@@ -3,12 +3,14 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/openhacku-saboten/OmnisCode-backend/domain/entity"
 )
 
 // User はユーザに関する永続化と再構築のためのリポジトリです
 type User interface {
-	FindByID(uid string) (user *entity.User, err error)
-	Insert(user *entity.User) error
-	Update(user *entity.User) error
+	FindByID(ctx context.Context, uid string) (user *entity.User, err error)
+	Insert(ctx context.Context, user *entity.User) error
+	Update(ctx context.Context, user *entity.User) error
 }

--- a/usecase/comment.go
+++ b/usecase/comment.go
@@ -20,8 +20,8 @@ func NewCommentUseCase(comment repository.Comment, post repository.Post) *Commen
 }
 
 // GetByPostID は引数のpostIDを満たす投稿にぶら下がるコメントを全て取得します
-func (u *CommentUseCase) GetByPostID(postID int) (comments []*entity.Comment, err error) {
-	comments, err = u.commentRepo.FindByPostID(postID)
+func (u *CommentUseCase) GetByPostID(ctx context.Context, postID int) (comments []*entity.Comment, err error) {
+	comments, err = u.commentRepo.FindByPostID(ctx, postID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetByPostID from DB: %w", err)
 	}
@@ -46,15 +46,15 @@ func (u *CommentUseCase) Create(ctx context.Context, comment *entity.Comment) er
 		return entity.ErrCannotCommit
 	}
 
-	if err := u.commentRepo.Insert(comment); err != nil {
+	if err := u.commentRepo.Insert(ctx, comment); err != nil {
 		return fmt.Errorf("failed to Insert Comment into DB: %w", err)
 	}
 	return nil
 }
 
 // Get は引数のpostIDとcommentIDの両方を満たすコメントを1つ取得します
-func (u *CommentUseCase) Get(postID, commentID int) (comment *entity.Comment, err error) {
-	comment, err = u.commentRepo.FindByID(postID, commentID)
+func (u *CommentUseCase) Get(ctx context.Context, postID, commentID int) (comment *entity.Comment, err error) {
+	comment, err = u.commentRepo.FindByID(ctx, postID, commentID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get comment from DB: %w", err)
 	}

--- a/usecase/mock/mock_comment.go
+++ b/usecase/mock/mock_comment.go
@@ -33,6 +33,19 @@ func (_m *MockComment) EXPECT() *MockCommentMockRecorder {
 	return _m.recorder
 }
 
+// FindByID mocks base method
+func (_m *MockComment) FindByID(ctx context.Context, postID int, commentID int) (*entity.Comment, error) {
+	ret := _m.ctrl.Call(_m, "FindByID", ctx, postID, commentID)
+	ret0, _ := ret[0].(*entity.Comment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByID indicates an expected call of FindByID
+func (_mr *MockCommentMockRecorder) FindByID(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "FindByID", reflect.TypeOf((*MockComment)(nil).FindByID), arg0, arg1, arg2)
+}
+
 // FindByUserID mocks base method
 func (_m *MockComment) FindByUserID(ctx context.Context, uid string) ([]*entity.Comment, error) {
 	ret := _m.ctrl.Call(_m, "FindByUserID", ctx, uid)
@@ -47,39 +60,26 @@ func (_mr *MockCommentMockRecorder) FindByUserID(arg0, arg1 interface{}) *gomock
 }
 
 // FindByPostID mocks base method
-func (_m *MockComment) FindByPostID(postID int) ([]*entity.Comment, error) {
-	ret := _m.ctrl.Call(_m, "FindByPostID", postID)
+func (_m *MockComment) FindByPostID(ctx context.Context, postID int) ([]*entity.Comment, error) {
+	ret := _m.ctrl.Call(_m, "FindByPostID", ctx, postID)
 	ret0, _ := ret[0].([]*entity.Comment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindByPostID indicates an expected call of FindByPostID
-func (_mr *MockCommentMockRecorder) FindByPostID(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "FindByPostID", reflect.TypeOf((*MockComment)(nil).FindByPostID), arg0)
+func (_mr *MockCommentMockRecorder) FindByPostID(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "FindByPostID", reflect.TypeOf((*MockComment)(nil).FindByPostID), arg0, arg1)
 }
 
 // Insert mocks base method
-func (_m *MockComment) Insert(comment *entity.Comment) error {
-	ret := _m.ctrl.Call(_m, "Insert", comment)
+func (_m *MockComment) Insert(ctx context.Context, comment *entity.Comment) error {
+	ret := _m.ctrl.Call(_m, "Insert", ctx, comment)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Insert indicates an expected call of Insert
-func (_mr *MockCommentMockRecorder) Insert(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "Insert", reflect.TypeOf((*MockComment)(nil).Insert), arg0)
-}
-
-// FindByID mocks base method
-func (_m *MockComment) FindByID(postID int, commentID int) (*entity.Comment, error) {
-	ret := _m.ctrl.Call(_m, "FindByID", postID, commentID)
-	ret0, _ := ret[0].(*entity.Comment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindByID indicates an expected call of FindByID
-func (_mr *MockCommentMockRecorder) FindByID(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "FindByID", reflect.TypeOf((*MockComment)(nil).FindByID), arg0, arg1)
+func (_mr *MockCommentMockRecorder) Insert(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "Insert", reflect.TypeOf((*MockComment)(nil).Insert), arg0, arg1)
 }

--- a/usecase/mock/mock_user.go
+++ b/usecase/mock/mock_user.go
@@ -4,6 +4,7 @@
 package mock
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	entity "github.com/openhacku-saboten/OmnisCode-backend/domain/entity"
 	reflect "reflect"
@@ -33,38 +34,38 @@ func (_m *MockUser) EXPECT() *MockUserMockRecorder {
 }
 
 // FindByID mocks base method
-func (_m *MockUser) FindByID(uid string) (*entity.User, error) {
-	ret := _m.ctrl.Call(_m, "FindByID", uid)
+func (_m *MockUser) FindByID(ctx context.Context, uid string) (*entity.User, error) {
+	ret := _m.ctrl.Call(_m, "FindByID", ctx, uid)
 	ret0, _ := ret[0].(*entity.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindByID indicates an expected call of FindByID
-func (_mr *MockUserMockRecorder) FindByID(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "FindByID", reflect.TypeOf((*MockUser)(nil).FindByID), arg0)
+func (_mr *MockUserMockRecorder) FindByID(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "FindByID", reflect.TypeOf((*MockUser)(nil).FindByID), arg0, arg1)
 }
 
 // Insert mocks base method
-func (_m *MockUser) Insert(user *entity.User) error {
-	ret := _m.ctrl.Call(_m, "Insert", user)
+func (_m *MockUser) Insert(ctx context.Context, user *entity.User) error {
+	ret := _m.ctrl.Call(_m, "Insert", ctx, user)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Insert indicates an expected call of Insert
-func (_mr *MockUserMockRecorder) Insert(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "Insert", reflect.TypeOf((*MockUser)(nil).Insert), arg0)
+func (_mr *MockUserMockRecorder) Insert(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "Insert", reflect.TypeOf((*MockUser)(nil).Insert), arg0, arg1)
 }
 
 // Update mocks base method
-func (_m *MockUser) Update(user *entity.User) error {
-	ret := _m.ctrl.Call(_m, "Update", user)
+func (_m *MockUser) Update(ctx context.Context, user *entity.User) error {
+	ret := _m.ctrl.Call(_m, "Update", ctx, user)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update
-func (_mr *MockUserMockRecorder) Update(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "Update", reflect.TypeOf((*MockUser)(nil).Update), arg0)
+func (_mr *MockUserMockRecorder) Update(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "Update", reflect.TypeOf((*MockUser)(nil).Update), arg0, arg1)
 }

--- a/usecase/user.go
+++ b/usecase/user.go
@@ -28,7 +28,7 @@ func NewUserUseCase(user repository.User, auth repository.Auth, post repository.
 
 // Get は引数のuidを満たすユーザを1つ取得します
 func (u *UserUseCase) Get(ctx context.Context, uid string) (user *entity.User, err error) {
-	user, err = u.userRepo.FindByID(uid)
+	user, err = u.userRepo.FindByID(ctx, uid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get User from DB: %w", err)
 	}
@@ -59,12 +59,12 @@ func (u *UserUseCase) GetPosts(ctx context.Context, uid string) ([]*entity.Post,
 }
 
 // Create は引数のユーザエンティティをもとにユーザを1つ生成します
-func (u *UserUseCase) Create(user *entity.User) error {
+func (u *UserUseCase) Create(ctx context.Context, user *entity.User) error {
 	if err := user.IsValid(); err != nil {
 		return fmt.Errorf("invalid user fields: %w", err)
 	}
 	user.Format()
-	if err := u.userRepo.Insert(user); err != nil {
+	if err := u.userRepo.Insert(ctx, user); err != nil {
 		return fmt.Errorf("failed to Insert User into DB: %w", err)
 	}
 	return nil
@@ -72,18 +72,18 @@ func (u *UserUseCase) Create(user *entity.User) error {
 
 // Update は引数のユーザエンティティをもとに、同じuidを持つユーザがいればそのユーザを更新します
 // 存在しないユーザの場合更新は行われません
-func (u *UserUseCase) Update(user *entity.User) error {
+func (u *UserUseCase) Update(ctx context.Context, user *entity.User) error {
 	if err := user.IsValid(); err != nil {
 		return fmt.Errorf("invalid user fields: %w", err)
 	}
 	user.Format()
 
 	// Updateは存在しないユーザーの更新をしてもエラーにならないので，ここでユーザーの存在確認をする
-	if _, err := u.userRepo.FindByID(user.ID); err != nil {
+	if _, err := u.userRepo.FindByID(ctx, user.ID); err != nil {
 		return fmt.Errorf("not found user %s in DB: %w", user.ID, err)
 	}
 
-	if err := u.userRepo.Update(user); err != nil {
+	if err := u.userRepo.Update(ctx, user); err != nil {
 		return fmt.Errorf("failed to Update User into DB: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## このPRの概要
リクエストが切れた時にDB操作も即時終了する機能を追加

## なぜこのPRが必要なのか
リクエストが切れた時に、リソースを可能な限り早く解放してGCに処理してもらうため
