### PR TITLE
feat: graceful shutdownを追加

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
+	"os/signal"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/openhacku-saboten/OmnisCode-backend/config"
@@ -72,8 +75,22 @@ func main() {
 	comment.POST("", commentController.Create, authMiddleware.Authenticate)
 	comment.GET("/:commentID", commentController.Get)
 
-	if err := e.Start(fmt.Sprintf(":%s", config.Port())); err != nil {
-		logger.Infof("shutting down the server with error' %s", err.Error())
-		os.Exit(1)
+	// ref: https://echo.labstack.com/cookbook/graceful-shutdown
+	// Start server
+	go func() {
+		if err := e.Start(fmt.Sprintf(":%s", config.Port())); err != nil && err != http.ErrServerClosed {
+			e.Logger.Fatal("shutting down the server")
+		}
+	}()
+
+	// Wait for interrupt signal to gracefully shutdown the server with a timeout of 10 seconds.
+	// Use a buffered channel to avoid missing signals as recommended for signal.Notify
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt)
+	<-quit
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := e.Shutdown(ctx); err != nil {
+		e.Logger.Fatal(err)
 	}
 }


### PR DESCRIPTION
## このPRの概要
graceful shutdownを追加

## なぜこのPRが必要なのか
処理の途中でAPIサーバが止まりそうになった時にDB操作が終わるまで少しの時間待機するため