### PR TITLE
Comment CreateのレスポンスにCommentの内容を含めるように修正 

### DIFF
--- a/controller/comment.go
+++ b/controller/comment.go
@@ -80,7 +80,7 @@ func (ctrl *CommentController) Create(c echo.Context) error {
 		logger.Errorf("error POST /post/{postID}/comment: %s", err.Error())
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
-	return c.NoContent(http.StatusCreated)
+	return c.JSON(http.StatusCreated, comment)
 }
 
 // Get は GET /post/{postID}/comment/{commentID} のHandler

--- a/controller/comment_test.go
+++ b/controller/comment_test.go
@@ -176,6 +176,7 @@ func TestCommentController_Create(t *testing.T) {
 		prepareMockPost    func(post *mock.MockPost)
 		wantErr            bool
 		wantCode           int
+		wantBody           string
 	}{
 		{
 			name:   "正しくコメントを作成できる",
@@ -185,7 +186,9 @@ func TestCommentController_Create(t *testing.T) {
 				"type": "highlight",
 				"content": "content1",
 				"first_line": 10,
-				"last_line": 12
+				"last_line": 12,
+				"created_at":"2021-03-23T11:42:56+09:00",
+				"updated_at":"2021-03-23T11:42:56+09:00"
 			}`,
 			prepareMockComment: func(comment *mock.MockComment) {
 				comment.EXPECT().Insert(
@@ -196,7 +199,12 @@ func TestCommentController_Create(t *testing.T) {
 						Content:   "content1",
 						FirstLine: 10,
 						LastLine:  12,
-					}).Return(nil)
+						CreatedAt: "2021-03-23T11:42:56+09:00",
+						UpdatedAt: "2021-03-23T11:42:56+09:00",
+					}).DoAndReturn(func(comment *entity.Comment) error {
+					comment.ID = 1
+					return nil
+				})
 			},
 			prepareMockPost: func(post *mock.MockPost) {
 				post.EXPECT().FindByID(gomock.Any(), 1).Return(
@@ -214,6 +222,18 @@ func TestCommentController_Create(t *testing.T) {
 			},
 			wantErr:  false,
 			wantCode: 201,
+			wantBody: `{
+				"id": 1,
+				"user_id": "user-id",
+				"post_id": 1,
+				"type": "highlight",
+				"content": "content1",
+				"first_line": 10,
+				"last_line": 12,
+				"code":"",
+				"created_at":"2021-03-23T11:42:56+09:00",
+				"updated_at":"2021-03-23T11:42:56+09:00"
+			}`,
 		},
 		{
 			name:   "Postのオーナー以外によるcommitならErrCannotCommit",
@@ -294,6 +314,20 @@ func TestCommentController_Create(t *testing.T) {
 			} else {
 				if rec.Code != tt.wantCode {
 					t.Errorf("code = %d, want = %d", rec.Code, tt.wantCode)
+				}
+			}
+
+			if !tt.wantErr {
+				var gotBody, wantBody map[string]interface{}
+				if err = json.Unmarshal(rec.Body.Bytes(), &gotBody); err != nil {
+					t.Fatal(err)
+				}
+				if err = json.Unmarshal([]byte(tt.wantBody), &wantBody); err != nil {
+					t.Fatal(err)
+				}
+
+				if diff := cmp.Diff(wantBody, gotBody); diff != "" {
+					t.Errorf("body (-want +got) =\n%s\n", diff)
 				}
 			}
 		})

--- a/controller/comment_test.go
+++ b/controller/comment_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"strings"
@@ -202,7 +203,7 @@ func TestCommentController_Create(t *testing.T) {
 						LastLine:  12,
 						CreatedAt: "2021-03-23T11:42:56+09:00",
 						UpdatedAt: "2021-03-23T11:42:56+09:00",
-					}).DoAndReturn(func(comment *entity.Comment) error {
+					}).DoAndReturn(func(ctx context.Context, comment *entity.Comment) error {
 					comment.ID = 1
 					return nil
 				})

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -314,6 +314,8 @@ paths:
       responses:
         "200":
           description: "successful operation"
+          schema:
+            $ref: "#/definitions/CommentResponse"
       security:
       - Bearer: []
   /post/{postID}/comment/{commentID}:

--- a/infra/comment.go
+++ b/infra/comment.go
@@ -89,7 +89,7 @@ func (r *CommentRepository) FindByUserID(ctx context.Context, uid string) ([]*en
 // Insert は該当ユーザーをDBに保存する
 func (r *CommentRepository) Insert(comment *entity.Comment) error {
 	commentDTO := &CommentInsertDTO{
-		ID:        comment.ID,
+		ID:        0,
 		UserID:    comment.UserID,
 		PostID:    comment.PostID,
 		Type:      comment.Type,
@@ -112,6 +112,9 @@ func (r *CommentRepository) Insert(comment *entity.Comment) error {
 		}
 		return err
 	}
+
+	comment.ID = commentDTO.ID
+
 	return nil
 }
 

--- a/infra/comment_test.go
+++ b/infra/comment_test.go
@@ -316,7 +316,7 @@ func TestUserRepository_GetByUserID(t *testing.T) {
 	}
 }
 
-func TestCommentRepository_Create(t *testing.T) {
+func TestCommentRepository_Insert(t *testing.T) {
 	dbMap, err := NewDB()
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -369,9 +369,10 @@ func TestCommentRepository_Create(t *testing.T) {
 	commentRepo := NewCommentRepository(dbMap)
 
 	tests := []struct {
-		name    string
-		comment *entity.Comment
-		wantErr error
+		name          string
+		comment       *entity.Comment
+		wantErr       error
+		wantCommentID int
 	}{
 		{
 			name: "正しくコメントを作成できる",
@@ -381,7 +382,8 @@ func TestCommentRepository_Create(t *testing.T) {
 				Type:    "none",
 				Content: "type none",
 			},
-			wantErr: nil,
+			wantErr:       nil,
+			wantCommentID: 2,
 		},
 		{
 			name: "IDが重複していてもAUTO_INCREMENTしてくれる",
@@ -392,7 +394,8 @@ func TestCommentRepository_Create(t *testing.T) {
 				Type:    "none",
 				Content: "type none",
 			},
-			wantErr: nil,
+			wantErr:       nil,
+			wantCommentID: 3,
 		},
 		{
 			name: "PostIDが存在しなければErrNotFound",
@@ -402,7 +405,8 @@ func TestCommentRepository_Create(t *testing.T) {
 				Type:    "none",
 				Content: "type none",
 			},
-			wantErr: entity.NewErrorNotFound("post"),
+			wantErr:       entity.NewErrorNotFound("post"),
+			wantCommentID: 0,
 		},
 		{
 			name: "UserIDが存在しなければErrNotFound",
@@ -412,13 +416,18 @@ func TestCommentRepository_Create(t *testing.T) {
 				Type:    "none",
 				Content: "type none",
 			},
-			wantErr: entity.NewErrorNotFound("user"),
+			wantErr:       entity.NewErrorNotFound("user"),
+			wantCommentID: 0,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := commentRepo.Insert(tt.comment)
+
+			if tt.comment.ID != tt.wantCommentID {
+				t.Errorf("gotCommentID = %d, want = %d", tt.comment.ID, tt.wantCommentID)
+			}
 
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)


### PR DESCRIPTION
## このPRの概要
Comment CreateのレスポンスにCommentの内容を含めるように修正 
#70 のCommentバージョン

## なぜこのPRが必要なのか
フロントが該当CommentのIDを取得できるようにするため
