### PR TITLE
fix: 正しく取得できていなかったIDを取得するように修正

### DIFF
--- a/controller/comment.go
+++ b/controller/comment.go
@@ -130,12 +130,6 @@ func (ctrl *CommentController) Update(c echo.Context) error {
 	comment.ID = commentID
 	comment.PostID = postID
 
-	comment.PostID, err = strconv.Atoi(c.Param("postID"))
-	if err != nil {
-		logger.Info(err.Error())
-		return echo.NewHTTPError(http.StatusBadRequest)
-	}
-
 	var ok bool
 	comment.UserID, ok = c.Get("userID").(string)
 	if !ok {

--- a/controller/comment.go
+++ b/controller/comment.go
@@ -114,13 +114,22 @@ func (ctrl *CommentController) Create(c echo.Context) error {
 func (ctrl *CommentController) Update(c echo.Context) error {
 	logger := log.New()
 
+	postID, err := strconv.Atoi(c.Param("postID"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest)
+	}
+	commentID, err := strconv.Atoi(c.Param("commentID"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest)
+	}
 	comment := &entity.Comment{}
 	if err := c.Bind(comment); err != nil {
 		logger.Info(err.Error())
 		return echo.NewHTTPError(http.StatusBadRequest)
 	}
+	comment.ID = commentID
+	comment.PostID = postID
 
-	var err error
 	comment.PostID, err = strconv.Atoi(c.Param("postID"))
 	if err != nil {
 		logger.Info(err.Error())

--- a/controller/comment_test.go
+++ b/controller/comment_test.go
@@ -490,6 +490,7 @@ func TestCommentController_Update(t *testing.T) {
 		name               string
 		postID             string
 		userID             string
+		commentID          string
 		body               string
 		prepareMockComment func(comment *mock.MockComment)
 		prepareMockPost    func(post *mock.MockPost)
@@ -498,11 +499,11 @@ func TestCommentController_Update(t *testing.T) {
 		wantCode           int
 	}{
 		{
-			name:   "正しくコメントを更新できる",
-			postID: "1",
-			userID: "user-id",
+			name:      "正しくコメントを更新できる",
+			postID:    "1",
+			userID:    "user-id",
+			commentID: "1",
 			body: `{
-				"id": 1,
 				"type": "highlight",
 				"content": "content1",
 				"first_line": 10,
@@ -542,9 +543,10 @@ func TestCommentController_Update(t *testing.T) {
 			wantCode: http.StatusOK,
 		},
 		{
-			name:   "Postのオーナー以外によるcommitならErrCannotCommit",
-			postID: "1",
-			userID: "user-id200",
+			name:      "Postのオーナー以外によるcommitならErrCannotCommit",
+			postID:    "1",
+			userID:    "user-id200",
+			commentID: "1",
 			body: `{
 				"type": "commit",
 				"content": "content1",
@@ -573,9 +575,10 @@ func TestCommentController_Update(t *testing.T) {
 			wantCode: http.StatusForbidden,
 		},
 		{
-			name:   "存在しないユーザによるcommitならErrNotFound",
-			postID: "1",
-			userID: "other-user-id",
+			name:      "存在しないユーザによるcommitならErrNotFound",
+			postID:    "1",
+			userID:    "other-user-id",
+			commentID: "1",
 			body: `{
 				"type": "commit",
 				"content": "content1",
@@ -591,9 +594,10 @@ func TestCommentController_Update(t *testing.T) {
 			wantCode: http.StatusNotFound,
 		},
 		{
-			name:   "存在しないPostIDならErrNotFound",
-			postID: "100",
-			userID: "user-id",
+			name:      "存在しないPostIDならErrNotFound",
+			postID:    "100",
+			userID:    "user-id",
+			commentID: "1",
 			body: `{
 				"type": "highlight",
 				"content": "content1",
@@ -619,8 +623,8 @@ func TestCommentController_Update(t *testing.T) {
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
-			c.SetParamNames("postID")
-			c.SetParamValues(tt.postID)
+			c.SetParamNames("postID", "commentID")
+			c.SetParamValues(tt.postID, tt.commentID)
 			c.Set("userID", tt.userID)
 
 			ctrl := gomock.NewController(t)

--- a/controller/post.go
+++ b/controller/post.go
@@ -101,11 +101,18 @@ func (ctrl *PostController) Create(c echo.Context) error {
 func (ctrl *PostController) Update(c echo.Context) error {
 	logger := log.New()
 
+	postID, err := strconv.Atoi(c.Param("postID"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest)
+	}
+
 	post := &entity.Post{}
 	if err := c.Bind(post); err != nil {
 		logger.Errorf("failed c.Bind: %s", err.Error())
 		return echo.NewHTTPError(http.StatusBadRequest)
 	}
+	post.ID = postID
+
 	var ok bool
 	post.UserID, ok = c.Get("userID").(string)
 	if !ok {

--- a/controller/post_test.go
+++ b/controller/post_test.go
@@ -296,6 +296,7 @@ func TestPostController_Update(t *testing.T) {
 	tests := []struct {
 		name            string
 		userID          string
+		postID          string
 		body            string
 		prepareMockPost func(ctx context.Context, post *mock.MockPost)
 		wantErr         bool
@@ -304,8 +305,8 @@ func TestPostController_Update(t *testing.T) {
 		{
 			name:   "正しく投稿を更新できる",
 			userID: "user-id",
+			postID: "1",
 			body: `{
-				"id": 1,
 				"title":"test title",
 				"code":"package main\n\nimport \"fmt\"\n\nfunc main(){fmt.Println(\"This is test.\")}",
 				"language":"Go",
@@ -333,6 +334,7 @@ func TestPostController_Update(t *testing.T) {
 		{
 			name:   "不正なBodyならBadRequest",
 			userID: "user-id",
+			postID: "1",
 			body: `{
 				"aaaa":"test title",
 				}`,
@@ -343,6 +345,7 @@ func TestPostController_Update(t *testing.T) {
 		{
 			name:            "bodyがJSON形式でないならBadRequest",
 			userID:          "user-id",
+			postID:          "1",
 			body:            `aaaaa`,
 			prepareMockPost: func(ctx context.Context, post *mock.MockPost) {},
 			wantErr:         true,
@@ -351,8 +354,8 @@ func TestPostController_Update(t *testing.T) {
 		{
 			name:   "存在しないポストならばErrIsNotAuthorでForbidden",
 			userID: "user-id",
+			postID: "100",
 			body: `{
-				"id": 100,
 				"title":"test title",
 				"code":"package main\n\nimport \"fmt\"\n\nfunc main(){fmt.Println(\"This is test.\")}",
 				"language":"Go",
@@ -380,8 +383,8 @@ func TestPostController_Update(t *testing.T) {
 		{
 			name:   "存在しないユーザならばErrNotFoundでForbidden",
 			userID: "user-id2002",
+			postID: "1",
 			body: `{
-				"id": 1,
 				"title":"test title",
 				"code":"package main\n\nimport \"fmt\"\n\nfunc main(){fmt.Println(\"This is test.\")}",
 				"language":"Go",
@@ -414,6 +417,8 @@ func TestPostController_Update(t *testing.T) {
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
+			c.SetParamNames("postID")
+			c.SetParamValues(tt.postID)
 			c.Set("userID", tt.userID)
 
 			ctx := context.Background()


### PR DESCRIPTION
## このPRの概要
URLのパスに含まれるIDを取得していなかったため修正

## なぜこのPRが必要なのか
postIDとcommentIDを用いて値が設定できず、正しく処理が行えなかったため