### PR TITLE
fix: GET /post/{postID} で、CodeとしてTitleを渡していたため修正

### DIFF
--- a/infra/post.go
+++ b/infra/post.go
@@ -80,7 +80,7 @@ func (p *PostRepository) FindByID(ctx context.Context, postID int) (*entity.Post
 			ID:        postDTO.ID,
 			UserID:    postDTO.UserID,
 			Title:     postDTO.Title,
-			Code:      postDTO.Title,
+			Code:      postDTO.Code,
 			Language:  postDTO.Language,
 			Content:   postDTO.Content,
 			Source:    postDTO.Source,


### PR DESCRIPTION
## このPRの概要
GET /post/{postID} で、CodeとしてTitleを渡していたため修正

## なぜこのPRが必要なのか
このままだとコードが取得できないため

